### PR TITLE
feat: add run.sh script for running benchmarks

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,17 @@
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_trec_covid' --initial_search 'BM25' # 完了
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir-v1.0.0-bioasq' --initial_search 'BM25' # 完了
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_nfcorpus' --initial_search 'BM25' # 完了
+python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_nq' --initial_search 'BM25'
+python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_hotpotqa' --initial_search 'BM25'
+python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_fiqa' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_signal1m' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_trec_news' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_robust04' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_arguana' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_webis_touche2020' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_quora' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_dbpedia_entity' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_scidocs' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_fever' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_climate_fever' --initial_search 'BM25'
+# python reshq/__main__.py --model 'unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit' --bench_mark 'beir_scifact' --initial_search 'BM25'


### PR DESCRIPTION
Added a new script `run.sh` to execute various benchmarks using the Meta-Llama-3.1-8B-Instruct-bnb-4bit model. The script includes commands for different benchmarks, some of which are commented out.